### PR TITLE
feat: Support passing JSON objects to message

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -19,7 +19,7 @@ var NowFunc = time.Now
 
 const traceFmt = "projects/%s/traces/%s"
 
-// WriteApplicationLog writes a application log to stdout
+// WriteApplicationLog writes an application log to stdout
 func WriteApplicationLog(ctx context.Context, s severity.Severity, format string, a ...interface{}) {
 	// Add a severity to the ContextSeverity
 	cs := severity.GetContextSeverity(ctx)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -18,6 +18,53 @@ import (
 
 /*
 Tests logger functions.
+The format of structured application log is below
+{
+  "severity":"INFO",
+	"jsonPayload": {
+		"value": "blah blah blah"
+	},
+  "time":"2020-12-31T23:59:59.999999999Z",
+  "logging.googleapis.com/sourceLocation":{
+    "file":"logger_test.go",
+    "line":"57",
+    "function":"github.com/glassonion1/logz.ExtractApplicationLogOut"
+  },
+  "logging.googleapis.com/trace":"projects/test/traces/00000000000000000000000000000000",
+  "logging.googleapis.com/spanId":"0000000000000000",
+  "logging.googleapis.com/trace_sampled":false
+}
+*/
+func TestLoggerWriteStructuredApplicationLog(t *testing.T) {
+
+	ctx := context.Background()
+
+	logger.NowFunc = func() time.Time {
+		return time.Date(2020, 12, 31, 23, 59, 59, 999999999, time.UTC)
+	}
+	config.ProjectID = "test"
+	config.CallerSkip = 1
+
+	defer func() {
+		config.CallerSkip = 0
+	}()
+
+	t.Run("Tests WriteStructuredApplicationLog function", func(t *testing.T) {
+		got := testhelper.ExtractApplicationLogOut(t, func() {
+			// tests the function
+			logger.WriteStructuredApplicationLog(ctx, severity.Info, map[string]string{"foo": "bar"})
+		})
+
+		expected := `{"severity":"INFO","message":{"foo":"bar"},"time":"2020-12-31T23:59:59.999999999Z","logging.googleapis.com/sourceLocation":{"file":"logger_test.go","line":"53","function":"github.com/glassonion1/logz/internal/logger_test.TestLoggerWriteStructuredApplicationLog.func3"},"logging.googleapis.com/trace":"projects/test/traces/00000000000000000000000000000000","logging.googleapis.com/spanId":"0000000000000000","logging.googleapis.com/trace_sampled":false}`
+
+		if diff := cmp.Diff(got, expected); diff != "" {
+			t.Errorf("failed log info test: %v", diff)
+		}
+	})
+}
+
+/*
+Tests logger functions.
 The format of application log is below
 {
   "severity":"INFO",
@@ -53,7 +100,7 @@ func TestLoggerWriteApplicationLog(t *testing.T) {
 			logger.WriteApplicationLog(ctx, severity.Info, "writes %s log", "info")
 		})
 
-		expected := `{"severity":"INFO","message":"writes info log","time":"2020-12-31T23:59:59.999999999Z","logging.googleapis.com/sourceLocation":{"file":"logger_test.go","line":"51","function":"github.com/glassonion1/logz/internal/logger_test.TestLoggerWriteApplicationLog.func3"},"logging.googleapis.com/trace":"projects/test/traces/00000000000000000000000000000000","logging.googleapis.com/spanId":"0000000000000000","logging.googleapis.com/trace_sampled":false}`
+		expected := `{"severity":"INFO","message":"writes info log","time":"2020-12-31T23:59:59.999999999Z","logging.googleapis.com/sourceLocation":{"file":"logger_test.go","line":"98","function":"github.com/glassonion1/logz/internal/logger_test.TestLoggerWriteApplicationLog.func3"},"logging.googleapis.com/trace":"projects/test/traces/00000000000000000000000000000000","logging.googleapis.com/spanId":"0000000000000000","logging.googleapis.com/trace_sampled":false}`
 
 		if diff := cmp.Diff(got, expected); diff != "" {
 			t.Errorf("failed log info test: %v", diff)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -15,10 +15,10 @@ type WriteAccessLogFunc func(ctx context.Context, req HTTPRequest)
 // WriteEmptyAccessLog writes empty log
 var WriteEmptyAccessLog = func(context.Context, HTTPRequest) {}
 
-// ApplicationLog is a log written by the developer by any timing
+// ApplicationLog is a structured log written by the developer by any timing
 type ApplicationLog struct {
 	Severity       string         `json:"severity"`
-	Message        string         `json:"message"`
+	Message        interface{}    `json:"message"`
 	Time           time.Time      `json:"time"`
 	SourceLocation SourceLocation `json:"logging.googleapis.com/sourceLocation"`
 	Trace          string         `json:"logging.googleapis.com/trace"`

--- a/logz.go
+++ b/logz.go
@@ -59,6 +59,31 @@ func SetConfig(cfg Config) {
 	}
 }
 
+// DebugStructured writes structured debug log to the stdout
+func DebugStructured(ctx context.Context, payload interface{}) {
+	logger.WriteStructuredApplicationLog(ctx, severity.Debug, payload)
+}
+
+// InfoStructured writes structured info log to the stdout
+func InfoStructured(ctx context.Context, payload interface{}) {
+	logger.WriteStructuredApplicationLog(ctx, severity.Info, payload)
+}
+
+// WarningStructured writes structured warning log to the stdout
+func WarningStructured(ctx context.Context, payload interface{}) {
+	logger.WriteStructuredApplicationLog(ctx, severity.Warning, payload)
+}
+
+// ErrorStructured writes structured error log to the stdout
+func ErrorStructured(ctx context.Context, payload interface{}) {
+	logger.WriteStructuredApplicationLog(ctx, severity.Error, payload)
+}
+
+// CriticalStructured writes structured critical log to the stdout
+func CriticalStructured(ctx context.Context, payload interface{}) {
+	logger.WriteStructuredApplicationLog(ctx, severity.Critical, payload)
+}
+
 // Debugf writes debug log to the stdout
 func Debugf(ctx context.Context, format string, a ...interface{}) {
 	logger.WriteApplicationLog(ctx, severity.Debug, format, a...)


### PR DESCRIPTION
# Motivation

Cloud Logging also accepts JSON objects LogEntry.
It is useful for creating metrics from its structured fields.

Currently, however, the functions that glassonion/logz provides such as `Infof` only accept string.

# Changed things

- extract the common implementation that constructs log entries to `writeAppLog`
- add `WriteStructuredApplicationLog` that accepts `interface{}` as `message`
- change `WriteApplicationLog` to only pass formatted string to `writeAppLog`
- add `{severity}Structured(ctx, payload)` functions to logz package that invoke `WriteStructuredApplicationLog`